### PR TITLE
[fix] pstack and firefox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-#
+CFLAGS=	-O0
+DEBUG_FLAGS=	-g
+
 PROG=	pstack
 SRCS=	elf.c pstack.c thread_db.c eh.c
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 PROG=	pstack
 SRCS=	elf.c pstack.c thread_db.c eh.c
 
+LDADD=	-lelftc
 # libthread_db.so calls back into gdb for the proc services.  Make all the
 # global symbols visible.
 LDFLAGS+= -Wl,-E

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #
 PROG=	pstack
-SRCS=	elf.c pstack.c thread_db.c
+SRCS=	elf.c pstack.c thread_db.c eh.c
 
 # libthread_db.so calls back into gdb for the proc services.  Make all the
 # global symbols visible.

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DEBUG_FLAGS=	-g
 PROG=	pstack
 SRCS=	elf.c pstack.c thread_db.c eh.c
 
-LDADD=	-lelftc
+LDADD=	-lcxxrt
 # libthread_db.so calls back into gdb for the proc services.  Make all the
 # global symbols visible.
 LDFLAGS+= -Wl,-E

--- a/eh.c
+++ b/eh.c
@@ -29,18 +29,15 @@
  * This file provides API to parse .eh_frame and .eh_frame_hdr sections of
  * binaries to retrieve frames without frame pointer information.
  */
-
 #include <sys/types.h>
 
-#include <dwarf.h>
-#include <elf.h>
-#include <err.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-
-#include "elfinfo.h"
 #include "eh.h"
+#include <dwarf.h>    // for DW_CFA_advance_loc, DW_CFA_advance_loc1, DW_CFA...
+#include <err.h>      // for warnx
+#include <stdio.h>    // for printf, NULL
+#include <stdlib.h>   // for free, malloc
+#include <string.h>   // for strcmp, strlen
+#include "elfinfo.h"  // for ElfObject
 
 /*
  * table - sorted table of FDEs

--- a/eh.c
+++ b/eh.c
@@ -39,7 +39,7 @@
 #include <string.h>   // for strcmp, strlen
 #include "elfinfo.h"  // for ElfObject
 
-static int	ehLogging = 0;
+static int	ehLogging = EH_PRINT_ALL;
 
 /*
  * table - sorted table of FDEs
@@ -70,6 +70,10 @@ ehFindFDE(const struct ehframehdr_item	*table, int count, int32_t key,
 	/* index of last item in table */
 	right = end;
 	left = 0;
+
+	if (ehLogging & EH_PRINT_FDE)
+		printf("ehFindFDE tbl: %p, count: %d, key: %x, start: %x, end: %x\n",
+		    table, count, key, table[0].rel_ip, table[end].rel_ip);
 
 	/* if there is only one element and it matches key */
 	if ((end == 0) && (table[0].rel_ip <= key)) {
@@ -151,7 +155,7 @@ ehLookupFrame(const struct ehframehdr *ehframehdr, const char* dataAddress,
 
 	if (ehFindFDE(&(ehframehdr->base), ehframehdr->n_fdecnt,
 	    rules->eh_rel_ip, &fde_offset) != 0)
-		return (-1);
+		return (-2);
 
 	cie_info = NULL;
 	fde_info = NULL;
@@ -237,7 +241,7 @@ clean:
 	if(fde_info != NULL)
 		free(fde_info);
 
-	return (-1);
+	return (-3);
 }
 
 void
@@ -261,8 +265,8 @@ int32_t
 ehGetRelativeIP(Elf_Addr ip, struct ElfObject *obj)
 {
 
-	return (ip - obj->baseAddr - 
-	    ((void*)obj->ehframeHeader - (void*)obj->fileData));
+	return (ip - obj->baseAddr -
+	    ((void*)obj->ehframeHeader - (void*)obj->fileData + obj->ehframe_phys_to_virt));
 }
 
 /*

--- a/eh.c
+++ b/eh.c
@@ -1,0 +1,565 @@
+/*
+ * Copyright (c) 2017 Michael Zhilin <mizhka@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+/*
+ * This file provides API to parse .eh_frame and .eh_frame_hdr sections of
+ * binaries to retrieve frames without frame pointer information.
+ */
+
+#include <sys/types.h>
+
+#include <dwarf.h>
+#include <elf.h>
+#include <err.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "elfinfo.h"
+#include "eh.h"
+
+/*
+ * table - sorted table of FDEs
+ * count - amount of FDEs in table
+ * key   - key to search
+ * ret   - found value
+ */
+
+static int	ehLogging = 0;
+
+static int	ehFindFDE(const struct ehframehdr_item	*table, int count,
+		    int32_t key, uint32_t *ret);
+
+static uint64_t	_dwarf_decode_uleb128(uint8_t **dp);
+static int64_t	_dwarf_decode_sleb128(uint8_t **dp);
+static int	_dwarf_frame_convert_inst(uint8_t addr_size,
+		    struct eh_record_info* info,
+		    struct eh_cfa_state *rules,
+		    uint32_t *count);
+static uint64_t	_dwarf_decode_lsb(uint8_t **data, int bytes_to_read);
+
+static int
+ehFindFDE(const struct ehframehdr_item	*table, int count, int32_t key, uint32_t *ret)
+{
+	const int			 end = count - 1;
+	int				 left, right, temp;
+
+	//index of last item in table
+	right = end;
+	left = 0;
+
+	// simple cases
+	if ((end == 0) && (table[0].rel_ip <= key))
+	{
+		temp = 0;
+		goto success;
+	}
+
+	if (end <= 0)
+		return (-1);
+
+	do {
+		temp = (left + right) >> 1;
+
+		// small region - check both
+		if (right - left == 1) {
+			if ((table[left].rel_ip <= key) && (table[right].rel_ip > key)) {
+				temp = left;
+				goto success;
+			}
+
+			if ((table[right].rel_ip <= key) && (right < end) && (table[right + 1].rel_ip > key)) {
+				temp = right;
+				goto success;
+			}
+
+			return (-1);
+		}
+
+		if (temp == left)
+			temp = left + 1;
+		else if (temp == right)
+			temp = right - 1;
+
+
+
+		// edge cases - success
+		if (((temp == end) && (table[temp].rel_ip < key)) ||
+		    ((temp == 0) && (table[1].rel_ip > key)))
+		{
+			goto success;
+		}
+
+		// edge cases - fail
+		if ((temp == end) || (temp == 0))
+			return (-1);
+
+		// successful
+		if (table[temp].rel_ip <= key) {
+			if (table[temp + 1].rel_ip > key)
+				goto success;
+			left = temp;
+		} else {
+			right = temp;
+		}
+	} while(1);
+
+success:
+	if (ehLogging & EH_PRINT_FDE)
+		printf("ehFindFDE cnt: %d, key: %d, index: %d, found_key:%d, value: %x\n",count, key, temp, table[temp].rel_ip, table[temp].offset);
+	*ret = table[temp].offset;
+
+	return (0);
+}
+
+int
+ehLookupFrame(const struct ehframehdr *ehframehdr, const char* dataAddress,
+    struct eh_cfa_state	*rules)
+{
+	const struct eh_record	*fde, *cie;
+	struct eh_cie_info	*cie_info;
+	struct eh_fde_info	*fde_info;
+	uint32_t		 fde_offset, cnt;
+	uint8_t			*tmp;
+	int			 err;
+
+	if (ehframehdr == NULL)
+		return (-1);
+
+	if (ehFindFDE(&(ehframehdr->base), ehframehdr->n_fdecnt,
+	    rules->eh_rel_ip, &fde_offset) != 0)
+		return (-1);
+
+	cie_info = malloc(sizeof(struct eh_cie_info));
+	fde_info = malloc(sizeof(struct eh_fde_info));
+
+	if(cie_info == NULL || fde_info == NULL)
+		goto clean;
+
+	fde = ((void*)ehframehdr + fde_offset);
+	cie = (void*) &(fde->common.cie_offset) - fde->common.cie_offset;
+
+	// Unsupported very long FDE. Probably impossible case
+	if (fde->common.len == 0xFFFFFFFF)
+		goto clean;
+
+	fde_info->common.base = ((void*)ehframehdr + fde_offset);
+	fde_info->common.len = fde->common.len + sizeof(fde->common.len);
+	fde_info->common.instr = ((void*)&(fde->fields.fde_specific.augmentation_len)) +
+	    sizeof(fde->fields.fde_specific.augmentation_len) +
+	    fde->fields.fde_specific.augmentation_len;
+	    //fde_info->common.base +
+	    //sizeof(struct eh_record_common) + sizeof(struct eh_record_fde) +
+	    //fde->fields.fde_specific.augmentation_len;
+
+	fde_info->common.instr_len = fde_info->common.len -
+	    (fde_info->common.instr - fde_info->common.base);
+
+	fde_info->pc_begin = (uint32_t)( (void*)&(fde->fields.fde_specific.pc_begin) -
+	    (void*)dataAddress) + fde->fields.fde_specific.pc_begin;
+	fde_info->pc_range = fde->fields.fde_specific.pc_range;
+
+	cie_info->common.base = (uint8_t *)cie;
+	cie_info->common.len = cie->common.len + sizeof(cie->common.len);
+	// plus one byte on version
+	cie_info->augmentation = (char *)cie_info->common.base +
+	    sizeof(struct eh_record_common) + sizeof(uint8_t);
+
+	//Unsupported case
+	if(strcmp(cie_info->augmentation, "zR") != 0){
+		warnx("cie_info: %s", cie_info->augmentation);
+		goto clean;
+	}
+	tmp = (uint8_t*)cie_info->augmentation + strlen(cie_info->augmentation) + 1;
+	cie_info->code_aligment = _dwarf_decode_uleb128(&tmp);
+	cie_info->data_aligment = _dwarf_decode_sleb128(&tmp);
+	cie_info->register_ra = *tmp++;
+	cie_info->common.instr = tmp + *tmp + sizeof(uint8_t);
+	cie_info->common.instr_len = cie_info->common.len -
+	    (cie_info->common.instr - cie_info->common.base);
+
+	if (ehLogging & EH_PRINT_FDE)
+		printf("FDE(%p, %d): (0x%x-0x%x) CIE(%p, %d): ra = %x\n",
+		    fde_info->common.base, fde_info->common.len, fde_info->pc_begin,
+		    fde_info->pc_begin + fde_info->pc_range, cie_info->common.base,
+		    cie_info->common.len, cie_info->register_ra);
+
+	rules->current_ip = fde_info->pc_begin;
+	rules->code_aligment = cie_info->code_aligment;
+	rules->data_aligment = cie_info->data_aligment;
+	rules->fde_offset = fde_offset;
+
+	if(fde->fields.fde_specific.augmentation_len == 0) {
+		err = _dwarf_frame_convert_inst(8, &(cie_info->common), rules, &cnt);
+		if (ehLogging & EH_PRINT_FDE)
+			printf("err: %d, cnt: %u\n", err, cnt);
+		// hackish code: I dunno why, but FDE requires shift of IP and SP
+		rules->current_ip++;
+		rules->cfaoffset -= rules->data_aligment;
+		err = _dwarf_frame_convert_inst(8, &(fde_info->common), rules, &cnt);
+		if (ehLogging & EH_PRINT_FDE)
+			printf("err: %d, cnt: %u\n", err, cnt);
+
+		if ((ehLogging & EH_PRINT_RULES) != 0)
+			ehPrintRules(rules);
+	}
+
+	return (0);
+clean:
+	if(cie_info != NULL)
+		free(cie_info);
+	if(fde_info != NULL)
+		free(fde_info);
+
+	return (-1);
+}
+
+void
+ehPrintRules(struct eh_cfa_state *rules)
+{
+
+	if (rules == NULL)
+		return;
+
+	printf("	0x%x: code aligned on %lu, data aligned on %ld\n", rules->target_ip, rules->code_aligment, rules->data_aligment);
+	printf("	CFA: reg<%d> off<%d>\n", rules->cfareg, rules->cfaoffset );
+	for (int i = 0; i < REGCNT; i++)
+		if(rules->reg[i] != 0)
+			printf("	REG[%d]: off<%d>\n", i, rules->reg[i]);
+}
+
+
+int32_t
+ehGetRelativeIP(Elf_Addr ip, struct ElfObject *obj)
+{
+
+	return (ip - obj->baseAddr - ((void*)obj->ehframeHeader - (void*)obj->fileData));
+}
+
+/*
+ * Passing of DWARF bytecode
+ * Taken from libdwarf to avoid full parsing of debug segments and adapted.
+ */
+
+typedef struct {
+	uint8_t		 fp_base_op;
+	uint8_t		 fp_extended_op;
+	uint16_t	 fp_register;
+	uint64_t	 fp_offset_or_block_len;
+	//uint8_t		*fp_expr_block;
+	uint64_t	 fp_instr_offset;
+} Dwarf_Frame_Op3;
+
+static int
+_dwarf_frame_convert_inst(uint8_t addr_size,
+    struct eh_record_info* info,
+    struct eh_cfa_state	*rules,
+    uint32_t *count)
+{
+	uint8_t 		*p, *pe;
+	uint8_t 		 high2, low6;
+	uint64_t 		 reg, reg2, uoff, soff, blen;
+
+#define	PRINTF(x, ...)					\
+	do {						\
+		if (ehLogging & EH_PRINT_BYTECODE)	\
+			printf(x, ## __VA_ARGS__ );	\
+	} while (0);
+
+	*count = 0;
+
+	p = info->instr;
+	pe = p + info->instr_len;
+
+	while (p < pe && rules->current_ip <= rules->target_ip) {
+		if (*p == DW_CFA_nop) {
+			p++;
+			PRINTF("	DW_CFA_nop\n");
+			(*count)++;
+			continue;
+		}
+
+		high2 = *p & 0xc0;
+		low6 = *p & 0x3f;
+		p++;
+
+		if (high2 > 0) {
+			switch (high2) {
+			case DW_CFA_advance_loc:
+//				SET_BASE_OP(high2);
+//				SET_OFFSET(low6);
+				rules->current_ip += low6 * rules->code_aligment;
+				PRINTF("	DW_CFA_advance_loc offset<%x>\n",low6);
+				break;
+			case DW_CFA_offset:
+//				SET_BASE_OP(high2);
+//				SET_REGISTER(low6);
+				uoff = _dwarf_decode_uleb128(&p);
+//				SET_OFFSET(uoff);
+				rules->reg[low6] = uoff * rules->data_aligment;
+				PRINTF("	DW_CFA_offset reg<%x> offset<%lx>\n",low6, uoff);
+				break;
+			case DW_CFA_restore:
+//				SET_BASE_OP(high2);
+//				SET_REGISTER(low6);
+				//rules->reg[low6] = 0;
+				// TODO: how to mark unused/restored values? bitmask?
+				warnx("UNIMPLEMENTED: DW_CFA_restore reg<%x>",low6);
+				break;
+			default:
+				return (-1);
+			}
+
+			(*count)++;
+			continue;
+		}
+
+//		SET_EXTENDED_OP(low6);
+//
+		switch (low6) {
+		case DW_CFA_set_loc:
+			uoff = _dwarf_decode_lsb(&p, addr_size);
+//			SET_OFFSET(uoff);
+			rules->current_ip = uoff;
+			PRINTF("	DW_CFA_set_loc uoff<%lx>\n",uoff);
+			break;
+		case DW_CFA_advance_loc1:
+			uoff = _dwarf_decode_lsb(&p, 1);
+//			SET_OFFSET(uoff);
+			rules->current_ip += uoff * rules->code_aligment;
+			PRINTF("	DW_CFA_advance_loc1 uoff<%lx>\n",uoff);
+			break;
+		case DW_CFA_advance_loc2:
+			uoff = _dwarf_decode_lsb(&p, 2);
+//			SET_OFFSET(uoff);
+			rules->current_ip += uoff * rules->code_aligment;
+			PRINTF("	DW_CFA_advance_loc2 uoff<%lx>\n",uoff);
+			break;
+		case DW_CFA_advance_loc4:
+			uoff = _dwarf_decode_lsb(&p, 4);
+//			SET_OFFSET(uoff);
+			rules->current_ip += uoff * rules->code_aligment;
+			PRINTF("	DW_CFA_advance_loc4 uoff<%lx>\n",uoff);
+			break;
+		case DW_CFA_offset_extended:
+			reg = _dwarf_decode_uleb128(&p);
+			uoff = _dwarf_decode_uleb128(&p);
+			rules->reg[reg] = uoff * rules->data_aligment;
+			PRINTF("	DW_CFA_offset_extended reg<%lx> uoff<%lx>\n",reg, uoff);
+			break;
+		case DW_CFA_def_cfa:
+			reg = _dwarf_decode_uleb128(&p);
+			uoff = _dwarf_decode_uleb128(&p);
+			rules->cfareg = reg;
+			rules->cfaoffset = uoff;
+			PRINTF("	DW_CFA_def_cfa reg<%lx> uoff<%lx>\n",reg, uoff);
+			break;
+		case DW_CFA_val_offset:
+			reg = _dwarf_decode_uleb128(&p);
+			uoff = _dwarf_decode_uleb128(&p);
+//			SET_REGISTER(reg);
+//			SET_OFFSET(uoff);
+			rules->reg[reg] = uoff * rules->data_aligment; // TODO: mark VAL_OFFSET
+			PRINTF("	DW_CFA_val_offset reg<%lx> uoff<%lx>\n",reg, uoff);
+			break;
+		case DW_CFA_restore_extended:
+			reg = _dwarf_decode_uleb128(&p);
+//			SET_REGISTER(reg);
+			//add implementation
+			warnx("	UNIMPLEMENTED: DW_CFA_restore_extended reg<%lx>",reg);
+			break;
+		case DW_CFA_undefined:
+			reg = _dwarf_decode_uleb128(&p);
+//			SET_REGISTER(reg);
+			//add implementation
+			warnx("	UNIMPLEMENTED: DW_CFA_undefined reg<%lx>",reg);
+			break;
+		case DW_CFA_same_value:
+			reg = _dwarf_decode_uleb128(&p);
+//			SET_REGISTER(reg);
+			//add implementation
+			warnx("	UNIMPLEMENTED: DW_CFA_same_value reg<%lx>",reg);
+			break;
+		case DW_CFA_def_cfa_register:
+			reg = _dwarf_decode_uleb128(&p);
+//			SET_REGISTER(reg);
+			rules->cfareg = reg;
+			PRINTF("	DW_CFA_def_cfa_register reg<%lx>\n",reg);
+			break;
+		case DW_CFA_register:
+			reg = _dwarf_decode_uleb128(&p);
+			reg2 = _dwarf_decode_uleb128(&p);
+//			SET_REGISTER(reg);
+//			SET_OFFSET(reg2);
+			//add implementation
+			warnx("UNIMPLEMENTED: DW_CFA_register reg<%lx> reg2<%lx>\n",reg, reg2);
+			break;
+		case DW_CFA_remember_state:
+			warnx("UNIMPLEMENTED: DW_CFA_remember_state\n");
+			break;
+			//add implementation
+		case DW_CFA_restore_state:
+			warnx("UNIMPLEMENTED: DW_CFA_restore_state\n");
+			break;
+			//add implementation
+		case DW_CFA_def_cfa_offset:
+			uoff = _dwarf_decode_uleb128(&p);
+//			SET_OFFSET(uoff);
+			rules->cfaoffset = uoff;
+			PRINTF("	DW_CFA_def_cfa_offset uoff<%lx>\n",uoff);
+			break;
+		case DW_CFA_def_cfa_expression:
+			blen = _dwarf_decode_uleb128(&p);
+//			SET_BLOCK_LEN(blen);
+			//add implementation
+			warnx("UNIMPLEMENTED: DW_CFA_def_cfa_expression blen<%lx>\n",blen);
+			//SET_EXPR_BLOCK(p, blen);
+			p += blen;
+			break;
+		case DW_CFA_expression:
+		case DW_CFA_val_expression:
+			reg = _dwarf_decode_uleb128(&p);
+			blen = _dwarf_decode_uleb128(&p);
+//			SET_REGISTER(reg);
+//			SET_BLOCK_LEN(blen);
+			//SET_EXPR_BLOCK(p, blen);
+			//add implementation
+			warnx("UNIMPLEMENTED: DW_CFA_expression/DW_CFA_val_expression reg<%lx> blen<%lx>\n",reg, blen);
+			p += blen;
+			break;
+		case DW_CFA_offset_extended_sf:
+			reg = _dwarf_decode_uleb128(&p);
+			soff = _dwarf_decode_sleb128(&p);
+			PRINTF("	DW_CFA_offset_extended_sf reg<%lx> soff<%lx>\n",reg, soff);
+			rules->reg[reg] = soff * rules->data_aligment;
+			break;
+		case DW_CFA_def_cfa_sf:
+			reg = _dwarf_decode_uleb128(&p);
+			soff = _dwarf_decode_sleb128(&p);
+			PRINTF("	DW_CFA_def_cfa_sf reg<%lx> soff<%lx>\n", reg, soff);
+			rules->cfareg = reg;
+			rules->cfaoffset = soff * rules->data_aligment;
+			break;
+		case DW_CFA_val_offset_sf:
+			reg = _dwarf_decode_uleb128(&p);
+			soff = _dwarf_decode_sleb128(&p);
+			PRINTF("	DW_CFA_val_offset_sf reg<%lx> soff<%lx>\n", reg, soff);
+			rules->reg[reg] = soff * rules->data_aligment; //TODO: mark VAL_OFFSET
+			break;
+		case DW_CFA_def_cfa_offset_sf:
+			soff = _dwarf_decode_sleb128(&p);
+//			SET_OFFSET(soff);
+			rules->cfaoffset = soff * rules->data_aligment;
+			PRINTF("	DW_CFA_def_cfa_offset_sf soff<%lx>\n",soff);
+			break;
+		default:
+			return (-1);
+		}
+
+		(*count)++;
+	}
+
+	return (0);
+}
+
+static int64_t
+_dwarf_decode_sleb128(uint8_t **dp)
+{
+	int64_t ret = 0;
+	uint8_t b;
+	int shift = 0;
+
+	uint8_t *src = *dp;
+
+	do {
+		b = *src++;
+		ret |= ((b & 0x7f) << shift);
+		shift += 7;
+	} while ((b & 0x80) != 0);
+
+	if (shift < 64 && (b & 0x40) != 0)
+		ret |= (-1 << shift);
+
+	*dp = src;
+
+	return (ret);
+}
+
+static uint64_t
+_dwarf_decode_uleb128(uint8_t **dp)
+{
+	uint64_t ret = 0;
+	uint8_t b;
+	int shift = 0;
+
+	uint8_t *src = *dp;
+
+	do {
+		b = *src++;
+		ret |= ((b & 0x7f) << shift);
+		shift += 7;
+	} while ((b & 0x80) != 0);
+
+	*dp = src;
+
+	return (ret);
+}
+
+static uint64_t
+_dwarf_decode_lsb(uint8_t **data, int bytes_to_read)
+{
+	uint64_t ret;
+	uint8_t *src;
+
+	src = *data;
+
+	ret = 0;
+	switch (bytes_to_read) {
+	case 8:
+		ret |= ((uint64_t) src[4]) << 32 | ((uint64_t) src[5]) << 40;
+		ret |= ((uint64_t) src[6]) << 48 | ((uint64_t) src[7]) << 56;
+		/* no break */
+	case 4:
+		ret |= ((uint64_t) src[2]) << 16 | ((uint64_t) src[3]) << 24;
+		/* no break */
+	case 2:
+		ret |= ((uint64_t) src[1]) << 8;
+		/* no break */
+	case 1:
+		ret |= src[0];
+		break;
+	default:
+		return (0);
+	}
+
+	*data += bytes_to_read;
+
+	return (ret);
+}
+
+
+

--- a/eh.h
+++ b/eh.h
@@ -1,0 +1,87 @@
+/*
+ * eh.h
+ *
+ *  Created on: Jul 30, 2017
+ *      Author: mizhka
+ */
+
+#ifndef EH_H_
+#define EH_H_
+
+struct ehframehdr_item {
+	int32_t rel_ip;
+	uint32_t offset;
+};
+
+struct ehframehdr {
+	uint32_t n_enc;
+	uint32_t n_ptr;
+	uint32_t n_fdecnt;
+	struct ehframehdr_item base;
+};
+
+struct eh_record_fde {
+	int32_t		pc_begin;
+	uint32_t	pc_range;
+	uint8_t		augmentation_len;
+} fde_specific;
+
+struct eh_record_common {
+	uint32_t	len;
+	int32_t		cie_offset;
+};
+
+struct eh_record {
+	struct eh_record_common		common;
+	union {
+		struct eh_record_fde	fde_specific;
+	} fields;
+};
+
+struct eh_record_info {
+	uint8_t		*base;
+	uint8_t		*instr;
+	uint32_t	 len;
+	uint32_t	 instr_len;
+};
+
+struct eh_fde_info {
+	struct eh_record_info	common;
+	int32_t			pc_begin;
+	uint32_t		pc_range;
+
+};
+
+struct eh_cie_info {
+	struct eh_record_info	common;
+	char*			augmentation;
+	uint64_t		code_aligment;
+	int64_t			data_aligment;
+	uint8_t			register_ra;
+};
+
+#define	REGCNT		200
+
+struct eh_cfa_state {
+	uint32_t	current_ip, target_ip;
+	uint32_t	fde_offset;
+	int32_t		eh_rel_ip;
+	uint32_t	cfareg;
+	uint32_t	cfaoffset;
+	uint64_t	code_aligment;
+	int64_t		data_aligment;
+	int32_t		reg[REGCNT];
+};
+
+enum {
+	EH_PRINT_RULES = 1,
+	EH_PRINT_BYTECODE = 2,
+	EH_PRINT_FDE = 4,
+	EH_PRINT_ALL = 255
+};
+
+int	ehLookupFrame(const struct ehframehdr *ehframehdr, const char* dataAddress, struct eh_cfa_state	*rules);
+int32_t ehGetRelativeIP(Elf_Addr ip, struct ElfObject *obj);
+void	ehPrintRules(struct eh_cfa_state *rules);
+
+#endif /* EH_H_ */

--- a/eh.h
+++ b/eh.h
@@ -8,6 +8,11 @@
 #ifndef EH_H_
 #define EH_H_
 
+#include <sys/_stdint.h>  // for uint32_t, int32_t, uint8_t, int64_t, uint64_t
+#include <x86/elf.h>      // for Elf_Addr
+
+struct ElfObject;
+
 struct ehframehdr_item {
 	int32_t rel_ip;
 	uint32_t offset;

--- a/eh.h
+++ b/eh.h
@@ -11,18 +11,31 @@
 #include <sys/_stdint.h>  // for uint32_t, int32_t, uint8_t, int64_t, uint64_t
 #include <x86/elf.h>      // for Elf_Addr
 
+#define	REGCNT	200
+
+/* Logging levels */
+
+enum {
+        EH_PRINT_RULES = 1,
+        EH_PRINT_BYTECODE = 2,
+        EH_PRINT_FDE = 4,
+        EH_PRINT_ALL = 255
+};
+
+/* Structures */
+
 struct ElfObject;
 
 struct ehframehdr_item {
-	int32_t rel_ip;
-	uint32_t offset;
+	int32_t		rel_ip;
+	uint32_t	offset;
 };
 
 struct ehframehdr {
-	uint32_t n_enc;
-	uint32_t n_ptr;
-	uint32_t n_fdecnt;
-	struct ehframehdr_item base;
+	uint32_t		n_enc;
+	uint32_t		n_ptr;
+	uint32_t		n_fdecnt;
+	struct ehframehdr_item	base;
 };
 
 struct eh_record_fde {
@@ -65,8 +78,6 @@ struct eh_cie_info {
 	uint8_t			register_ra;
 };
 
-#define	REGCNT		200
-
 struct eh_cfa_state {
 	uint32_t	current_ip, target_ip;
 	uint32_t	fde_offset;
@@ -78,14 +89,9 @@ struct eh_cfa_state {
 	int32_t		reg[REGCNT];
 };
 
-enum {
-	EH_PRINT_RULES = 1,
-	EH_PRINT_BYTECODE = 2,
-	EH_PRINT_FDE = 4,
-	EH_PRINT_ALL = 255
-};
 
-int	ehLookupFrame(const struct ehframehdr *ehframehdr, const char* dataAddress, struct eh_cfa_state	*rules);
+int	ehLookupFrame(const struct ehframehdr *ehframehdr, 
+	    const char *dataAddress, struct eh_cfa_state *rules);
 int32_t ehGetRelativeIP(Elf_Addr ip, struct ElfObject *obj);
 void	ehPrintRules(struct eh_cfa_state *rules);
 

--- a/eh.h
+++ b/eh.h
@@ -16,6 +16,7 @@
 /* Logging levels */
 
 enum {
+        EH_PRINT_NONE = 0,
         EH_PRINT_RULES = 1,
         EH_PRINT_BYTECODE = 2,
         EH_PRINT_FDE = 4,
@@ -31,9 +32,19 @@ struct ehframehdr_item {
 	uint32_t	offset;
 };
 
+
+/*
+ * This is combination of
+ *   version (uint8)            structure version (=1)
+ *   eh_frame_ptr_enc (uint8)   encoding of eh_frame_ptr
+ *   fde_count_enc (uint8)      encoding of fde_count
+ *   table_enc (uint8)          encoding of table entries
+ */
+#define	EH_FRAME_MAGIC	0x3b031b01
+
 struct ehframehdr {
-	uint32_t		n_enc;
-	uint32_t		n_ptr;
+	uint32_t		magic;
+	uint32_t		n_ptr; // pointer to eh_frame section
 	uint32_t		n_fdecnt;
 	struct ehframehdr_item	base;
 };
@@ -42,7 +53,7 @@ struct eh_record_fde {
 	int32_t		pc_begin;
 	uint32_t	pc_range;
 	uint8_t		augmentation_len;
-} fde_specific;
+};
 
 struct eh_record_common {
 	uint32_t	len;

--- a/elf.c
+++ b/elf.c
@@ -160,12 +160,19 @@ elfLoadObject(const char *fileName, struct ElfObject **objp)
 	if (elfFindSectionByName(obj, ".eh_frame_hdr", &shdr) != -1) {
 		obj->ehframeHeader = ehFrameHdr = (struct ehframehdr*)
 		   (obj->fileData + shdr->sh_offset);
-		if (ehFrameHdr->n_enc != 0x3b031b01) {
+		obj->ehframe_phys_to_virt= shdr->sh_addr - shdr->sh_offset;
+		if (ehFrameHdr->magic != EH_FRAME_MAGIC) {
 			warnx("Untypical case of eh_frame_hdr, skip parsing");
 			printf("type: %x ptr: %x fdecnt: %x\n", 
-			    ehFrameHdr->n_enc, ehFrameHdr->n_ptr, 
+			    ehFrameHdr->magic, ehFrameHdr->n_ptr,
 			    ehFrameHdr->n_fdecnt);
 		}
+	} else if(elfFindSectionByName(obj, ".zdebug_frame", &shdr) != -1) {
+		/*
+		 * Golang doesn't use error handling
+		 */
+		printf("Found compressed DWARF frame section. need support\n");
+
 	}
 
 	return (0);

--- a/elf.c
+++ b/elf.c
@@ -98,6 +98,7 @@ elfLoadObject(const char *fileName, struct ElfObject **objp)
 	}
 	obj->programHeaders = pHdrs =
 	    malloc(sizeof(Elf_Phdr *) * (eHdr->e_phnum + 1));
+	obj->baseAddr = 0;
 	for (p = data + eHdr->e_phoff, i = 0; i < eHdr->e_phnum; i++) {
 		pHdrs[i] = (const Elf_Phdr *)p;
 		switch (pHdrs[i]->p_type) {
@@ -107,6 +108,13 @@ elfLoadObject(const char *fileName, struct ElfObject **objp)
 		case PT_DYNAMIC:
 			obj->dynamic = pHdrs[i];
 			break;
+		/*
+		 * Check program headers for load address. If it's ZERO, then
+		 * kernel will load object in ET_DYN_LOAD_ADDRESS
+		 */
+		case PT_LOAD:
+			if (pHdrs[i]->p_paddr == 0 && pHdrs[i]->p_vaddr == 0)
+				obj->baseAddr = ET_DYN_LOAD_ADDR;
 		}
 		p += eHdr->e_phentsize;
 	}

--- a/elfinfo.h
+++ b/elfinfo.h
@@ -50,6 +50,7 @@ struct ElfObject {
 	const char 	*stabStrings;
 	int		 stabCount;
 	const struct ehframehdr	*ehframeHeader;
+	uint32_t	ehframe_phys_to_virt;
 };
 
 struct stab {

--- a/elfinfo.h
+++ b/elfinfo.h
@@ -49,6 +49,7 @@ struct ElfObject {
 	const struct stab *stabs;
 	const char 	*stabStrings;
 	int		 stabCount;
+	const struct ehframehdr	*ehframeHeader;
 };
 
 struct stab {

--- a/pstack.1
+++ b/pstack.1
@@ -12,9 +12,11 @@
 .Op Fl a Ar arg-count
 .Op Fl e Ar executable-file
 .Op Fl f Ar frame-count
+.Op Fl n Ar iteration-count
 .Op Fl o
 .Op Fl O
 .Op Fl t
+.Op Fl T Ar thread-id
 .Op Fl v
 .Ar pid | core
 .Nm
@@ -43,9 +45,17 @@ to print a dump of the ELF information in an object file,
 and exit.
 .It Fl e Ar file
 Specify an alternate executable to use for locating symbols in the
-process.  This is useful if the process was started from a stripped
+process.
+This is useful if the process was started from a stripped
 version of an executable, and you have the unstripped version
-available. If examining a corefile, this argument is required.
+available.
+If examining a corefile, this argument is required.
+.It Fl n Ar iteration-count
+Causes
+.Nm
+to display stack traces
+.Ar iteration-count
+times
 .It Fl o
 For each stack frame, display the name of the object in which the current
 function lies
@@ -55,8 +65,11 @@ the current function lies
 .It Fl t
 Display the amount of time that the process was suspended by
 .Nm
+.It Fl T Ar thread-id
+Display stack frame only for thread with specified thread ID
 .It Fl v
-verbose. Display debugging and diagnostics.
+verbose.
+Display debugging and diagnostics.
 .El
 .Sh SEE ALSO
 .Xr ptrace 2
@@ -64,6 +77,6 @@ verbose. Display debugging and diagnostics.
 .Nm
 works only for x86 32/64-bit ELF executables at the moment. (ie, no
 a.out support, and no Alpha support).
-It is also very dependent on the current FreeBSD threads implementation. 
+It is also very dependent on the current FreeBSD threads implementation.
 .Sh AUTHORS
 Peter Edwards <pmedwards@eircom.net>

--- a/pstack.h
+++ b/pstack.h
@@ -7,6 +7,8 @@ struct StackFrame {
 	STAILQ_ENTRY(StackFrame) link;
 	Elf_Addr	ip;
 	Elf_Addr	bp;
+	Elf_Addr	sp;
+	char		broken;
 	int		argCount;
 	Elf_Word	args[1];
 };
@@ -64,7 +66,7 @@ size_t	procReadMem(struct Process *proc, void *ptr, Elf_Addr remoteAddr,
 int	procReadVar(struct Process *proc, struct ElfObject *obj,
 	    const char *name, int *value);
 struct Thread *procReadThread(struct Process *proc, Elf_Addr bp,
-	    Elf_Addr ip);
+	    Elf_Addr ip, Elf_Addr sp);
 size_t	procWriteMem(struct Process *proc, const void *ptr, Elf_Addr remoteAddr,
 	    size_t size);
 

--- a/pstack.h
+++ b/pstack.h
@@ -70,4 +70,10 @@ struct Thread *procReadThread(struct Process *proc, Elf_Addr bp,
 size_t	procWriteMem(struct Process *proc, const void *ptr, Elf_Addr remoteAddr,
 	    size_t size);
 
+/* Use C++ ABI to demangle C++ functions */
+char* __cxa_demangle(const char* mangled_name,
+                     char* buf,
+                     size_t* n,
+                     int* status);
+
 #endif

--- a/pstack.h
+++ b/pstack.h
@@ -57,6 +57,7 @@ struct thread_ops {
 };
 
 extern struct thread_ops thread_db_ops;
+extern int gThreadID;
 
 size_t	procReadMem(struct Process *proc, void *ptr, Elf_Addr remoteAddr,
 	    size_t size);

--- a/thread_db.c
+++ b/thread_db.c
@@ -175,9 +175,9 @@ find_new_threads_callback(const td_thrhandle_t *th_p, void *data)
 
 	proc = data;
 #ifdef __LP64__
-	t = procReadThread(proc, gregset[0].r_rbp, gregset[0].r_rip);
+	t = procReadThread(proc, gregset[0].r_rbp, gregset[0].r_rip, gregset[0].r_rsp);
 #else
-	t = procReadThread(proc, gregset[0].r_ebp, gregset[0].r_eip);
+	t = procReadThread(proc, gregset[0].r_ebp, gregset[0].r_eip, gregset[0].r_esp);
 #endif
 	if (t != NULL) {
 		t->id = ti.ti_tid;

--- a/thread_db.c
+++ b/thread_db.c
@@ -159,6 +159,9 @@ find_new_threads_callback(const td_thrhandle_t *th_p, void *data)
 		return (0);
 	}
 
+	if (gThreadID != -1 && gThreadID != ti.ti_tid)
+		return (0);
+
 	/* Ignore zombie */
 	if (ti.ti_state == TD_THR_UNKNOWN || ti.ti_state == TD_THR_ZOMBIE)
 		return (0);


### PR DESCRIPTION
Hi,

This fix allows to load information about shared libraries correctly if base address is ZERO and virtual load address is ZERO. kern/imgact_elf will use ET_DYN_LOAD_ADDR as load address (https://svnweb.freebsd.org/base/head/sys/kern/imgact_elf.c?revision=320481&view=markup#l895) in this case. 
For testing purpose on 11.1 and 12-current, patch on libthr is required: https://reviews.freebsd.org/D11738 

There are few cosmetic changes to improve verbose mode.